### PR TITLE
feature: zod adapter update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "vite-plugin-dts": "^4.5.3",
         "vitest": "^3.1.2",
         "yup": "^1.6.1",
-        "zod": "^3.24.3"
+        "zod": "^3.25.67"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -16220,9 +16220,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
-      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "vite-plugin-dts": "^4.5.3",
     "vitest": "^3.1.2",
     "yup": "^1.6.1",
-    "zod": "^3.24.3"
+    "zod": "^3.25.67"
   },
   "scripts": {
     "update-deps": "lerna exec npm install",

--- a/packages/effector-reform-zod/lib/adapter.ts
+++ b/packages/effector-reform-zod/lib/adapter.ts
@@ -3,20 +3,22 @@ import type {
   AsyncValidationFn,
   ErrorsSchemaPayload,
 } from '@effector-reform/core';
-import { ZodError, ZodType } from 'zod';
+import { parseAsync } from 'zod/v4/core';
+import { isZodV4Schema, ZodAnyError, ZodAnyType } from './utils';
 
 export function zodAdapter<Schema extends AnySchema>(
-  schema: ZodType<any, any, any>,
+  schema: ZodAnyType,
 ): AsyncValidationFn<Schema> {
   return async (values): Promise<ErrorsSchemaPayload | null> => {
     try {
-      await schema.parseAsync(values);
+      if (isZodV4Schema(schema)) await parseAsync(schema, values);
+      else await schema.parseAsync(values);
 
       return null;
     } catch (e) {
-      const { errors } = e as ZodError;
+      const { issues } = e as ZodAnyError;
 
-      return errors.reduce((acc: ErrorsSchemaPayload, error) => {
+      return issues.reduce((acc: ErrorsSchemaPayload, error) => {
         if (acc[error.path.join('.')]) {
           return acc;
         }

--- a/packages/effector-reform-zod/lib/utils.ts
+++ b/packages/effector-reform-zod/lib/utils.ts
@@ -1,0 +1,17 @@
+import {
+  type ZodType as ZodTypeV3,
+  type ZodError as ZodErrorV3,
+} from 'zod/v3';
+import {
+  type $ZodType as ZodTypeV4,
+  type $ZodError as ZodErrorV4,
+} from 'zod/v4/core';
+
+type ZodAnyType = ZodTypeV3 | ZodTypeV4;
+type ZodAnyError = ZodErrorV3 | ZodErrorV4;
+
+function isZodV4Schema(schema: unknown): schema is ZodTypeV4 {
+  return !!schema && typeof schema === 'object' && '_zod' in schema;
+}
+
+export { isZodV4Schema, ZodAnyType, ZodAnyError };

--- a/packages/effector-reform-zod/package.json
+++ b/packages/effector-reform-zod/package.json
@@ -55,5 +55,8 @@
   },
   "dependencies": {
     "@effector-reform/core": "^0.16.0"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.0 || ^4.0.0"
   }
 }

--- a/packages/effector-reform-zod/tests/adapter.test.ts
+++ b/packages/effector-reform-zod/tests/adapter.test.ts
@@ -1,184 +1,547 @@
 import { describe, expect, test } from 'vitest';
 import { createArrayField, createForm } from '@effector-reform/core';
 import { zodAdapter } from '../lib';
-import { z } from 'zod';
+import { z as zodV3 } from 'zod/v3';
+import { z as zodV4 } from 'zod/v4';
+import { z as zodV4mini } from 'zod/v4-mini';
 import { allSettled, fork } from 'effector';
 
 describe('Zod adapter', () => {
-  test('zod', async () => {
-    const scope = fork();
-    const form = createForm({
-      schema: {
-        a: 5,
-        b: createArrayField<number>([]),
-        c: { d: 'string' },
-      },
-      validation: zodAdapter(
-        z.object({
-          a: z.number().max(20),
-          b: z.array(z.number()).min(5).max(10),
-          c: z.object({ d: z.string().min(2).max(10) }),
-        }),
-      ),
-    });
-
-    await allSettled(form.validate, { scope });
-    await allSettled(form.fields.c.d.change, { scope, params: 'h' });
-    await allSettled(form.submit, { scope });
-
-    const errors = scope.getState(form.$errors);
-
-    expect(errors).toStrictEqual({
-      a: null,
-      b: {
-        error: 'Array must contain at least 5 element(s)',
-        errors: [],
-      },
-      c: { d: 'String must contain at least 2 character(s)' },
-    });
-  });
-
-  test('clear not settled errors', async () => {
-    const scope = fork();
-    const form = createForm({
-      schema: {
-        a: '',
-        b: '',
-      },
-      validation: zodAdapter(
-        z.object({
-          a: z.string().min(2, 'min 2'),
-          b: z.string().min(4, 'min 4'),
-        }),
-      ),
-    });
-
-    await allSettled(form.fill, {
-      scope,
-      params: { values: { a: 'a', b: 'a' } },
-    });
-
-    expect(scope.getState(form.$errors)).toStrictEqual({
-      a: 'min 2',
-      b: 'min 4',
-    });
-
-    await allSettled(form.fields.a.change, { scope, params: 'aa' });
-
-    expect(scope.getState(form.$errors)).toStrictEqual({
-      a: null,
-      b: 'min 4',
-    });
-  });
-
-  test('works with refine', async () => {
-    const scope = fork();
-    const form = createForm({
-      schema: {
-        password: '',
-        confirm: '',
-      },
-      validation: zodAdapter(
-        z
-          .object({
-            password: z.string(),
-            confirm: z.string(),
-          })
-          .refine((data) => data.password === data.confirm, {
-            message: "don't match",
-            path: ['confirm'],
+  describe.each([{ z: zodV3, mark: "zod v3" }])('$mark', ({ z }) => {
+    test('zod', async () => {
+      const scope = fork();
+      const form = createForm({
+        schema: {
+          a: 5,
+          b: createArrayField<number>([]),
+          c: { d: 'string' },
+        },
+        validation: zodAdapter(
+          z.object({
+            a: z.number().max(20),
+            b: z.array(z.number()).min(5).max(10),
+            c: z.object({ d: z.string().min(2).max(10) }),
           }),
-      ),
+        ),
+      });
+
+      await allSettled(form.validate, { scope });
+      await allSettled(form.fields.c.d.change, { scope, params: 'h' });
+      await allSettled(form.submit, { scope });
+
+      const errors = scope.getState(form.$errors);
+
+      expect(errors).toStrictEqual({
+        a: null,
+        b: {
+          error: 'Array must contain at least 5 element(s)',
+          errors: [],
+        },
+        c: { d: 'String must contain at least 2 character(s)' },
+      });
     });
 
-    await allSettled(form.fill, {
-      scope,
-      params: { values: { password: '1234', confirm: '00' } },
+    test('clear not settled errors', async () => {
+      const scope = fork();
+      const form = createForm({
+        schema: {
+          a: '',
+          b: '',
+        },
+        validation: zodAdapter(
+          z.object({
+            a: z.string().min(2, 'min 2'),
+            b: z.string().min(4, 'min 4'),
+          }),
+        ),
+      });
+
+      await allSettled(form.fill, {
+        scope,
+        params: { values: { a: 'a', b: 'a' } },
+      });
+
+      expect(scope.getState(form.$errors)).toStrictEqual({
+        a: 'min 2',
+        b: 'min 4',
+      });
+
+      await allSettled(form.fields.a.change, { scope, params: 'aa' });
+
+      expect(scope.getState(form.$errors)).toStrictEqual({
+        a: null,
+        b: 'min 4',
+      });
     });
 
-    expect(scope.getState(form.$errors)).toStrictEqual({
-      password: null,
-      confirm: "don't match",
-    });
-
-    await allSettled(form.fields.confirm.change, { scope, params: '1234' });
-
-    expect(scope.getState(form.$errors)).toStrictEqual({
-      password: null,
-      confirm: null,
-    });
-  });
-
-  test('works with discriminated union', async () => {
-    const scope = fork();
-
-    const commonSchema = z.object({ name: z.string().nonempty() });
-
-    const form = createForm({
-      schema: {
-        name: '',
-        contractType: '',
-        contractId: '',
-      },
-      validation: zodAdapter(
-        z.discriminatedUnion('contractType', [
-          commonSchema.extend({
-            contractType: z.literal('a'),
-            contractId: z.literal('', {
-              errorMap: () => ({ message: 'should be empty' }),
+    test('works with refine', async () => {
+      const scope = fork();
+      const form = createForm({
+        schema: {
+          password: '',
+          confirm: '',
+        },
+        validation: zodAdapter(
+          z
+            .object({
+              password: z.string(),
+              confirm: z.string(),
+            })
+            .refine((data) => data.password === data.confirm, {
+              message: "don't match",
+              path: ['confirm'],
             }),
+        ),
+      });
+
+      await allSettled(form.fill, {
+        scope,
+        params: { values: { password: '1234', confirm: '00' } },
+      });
+
+      expect(scope.getState(form.$errors)).toStrictEqual({
+        password: null,
+        confirm: "don't match",
+      });
+
+      await allSettled(form.fields.confirm.change, { scope, params: '1234' });
+
+      expect(scope.getState(form.$errors)).toStrictEqual({
+        password: null,
+        confirm: null,
+      });
+    });
+
+    test('works with discriminated union', async () => {
+      const scope = fork();
+
+      const commonSchema = z.object({ name: z.string().nonempty() });
+
+      const form = createForm({
+        schema: {
+          name: '',
+          contractType: '',
+          contractId: '',
+        },
+        validation: zodAdapter(
+          z.discriminatedUnion('contractType', [
+            commonSchema.extend({
+              contractType: z.literal('a'),
+              contractId: z.literal('', {
+                errorMap: () => ({ message: 'should be empty' }),
+              }),
+            }),
+            commonSchema.extend({
+              contractType: z.literal('b'),
+              contractId: z.string().nonempty(),
+            }),
+          ]),
+        ),
+      });
+
+      await allSettled(form.fill, {
+        scope,
+        params: {
+          values: { name: 'Test', contractType: 'a', contractId: '123' },
+        },
+      });
+
+      expect(scope.getState(form.$errors)).toStrictEqual({
+        name: null,
+        contractType: null,
+        contractId: 'should be empty',
+      });
+
+      await allSettled(form.fields.contractType.change, {
+        scope,
+        params: 'b',
+      });
+
+      expect(scope.getState(form.$errors)).toStrictEqual({
+        name: null,
+        contractType: null,
+        contractId: null,
+      });
+    });
+
+    test('errors has right order', async () => {
+      const scope = fork();
+      const form = createForm({
+        schema: {
+          email: '',
+        },
+        validation: zodAdapter(
+          z.object({
+            email: z.string().min(2, 'invalid length').email('invalid email'),
           }),
-          commonSchema.extend({
-            contractType: z.literal('b'),
-            contractId: z.string().nonempty(),
-          }),
-        ]),
-      ),
-    });
+        ),
+      });
 
-    await allSettled(form.fill, {
-      scope,
-      params: {
-        values: { name: 'Test', contractType: 'a', contractId: '123' },
-      },
-    });
+      await allSettled(form.fill, {
+        scope,
+        params: { values: { email: '1' } },
+      });
 
-    expect(scope.getState(form.$errors)).toStrictEqual({
-      name: null,
-      contractType: null,
-      contractId: 'should be empty',
-    });
-
-    await allSettled(form.fields.contractType.change, {
-      scope,
-      params: 'b',
-    });
-
-    expect(scope.getState(form.$errors)).toStrictEqual({
-      name: null,
-      contractType: null,
-      contractId: null,
+      expect(scope.getState(form.$errors).email).toBe('invalid length');
     });
   });
 
-  test('errors has right order', async () => {
-    const scope = fork();
-    const form = createForm({
-      schema: {
-        email: '',
-      },
-      validation: zodAdapter(
-        z.object({
-          email: z.string().min(2, 'invalid length').email('invalid email'),
-        }),
-      ),
+  describe.each([{ z: zodV4, mark: "zod v4" }])('$mark', ({ z }) => {
+    test('zod', async () => {
+      const scope = fork();
+      const form = createForm({
+        schema: {
+          a: 5,
+          b: createArrayField<number>([]),
+          c: { d: 'string' },
+        },
+        validation: zodAdapter(
+          z.object({
+            a: z.number().max(20),
+            b: z.array(z.number()).min(5).max(10),
+            c: z.object({ d: z.string().min(2).max(10) }),
+          }),
+        ),
+      });
+
+      await allSettled(form.validate, { scope });
+      await allSettled(form.fields.c.d.change, { scope, params: 'h' });
+      await allSettled(form.submit, { scope });
+
+      const errors = scope.getState(form.$errors);
+
+      expect(errors).toStrictEqual({
+        a: null,
+        b: {
+          error: 'Too small: expected array to have >=5 items',
+          errors: [],
+        },
+        c: { d: 'Too small: expected string to have >=2 characters' },
+      });
     });
 
-    await allSettled(form.fill, {
-      scope,
-      params: { values: { email: '1' } },
+    test('clear not settled errors', async () => {
+      const scope = fork();
+      const form = createForm({
+        schema: {
+          a: '',
+          b: '',
+        },
+        validation: zodAdapter(
+          z.object({
+            a: z.string().min(2, 'min 2'),
+            b: z.string().min(4, 'min 4'),
+          }),
+        ),
+      });
+
+      await allSettled(form.fill, {
+        scope,
+        params: { values: { a: 'a', b: 'a' } },
+      });
+
+      expect(scope.getState(form.$errors)).toStrictEqual({
+        a: 'min 2',
+        b: 'min 4',
+      });
+
+      await allSettled(form.fields.a.change, { scope, params: 'aa' });
+
+      expect(scope.getState(form.$errors)).toStrictEqual({
+        a: null,
+        b: 'min 4',
+      });
     });
 
-    expect(scope.getState(form.$errors).email).toBe('invalid length');
+    test('works with refine', async () => {
+      const scope = fork();
+      const form = createForm({
+        schema: {
+          password: '',
+          confirm: '',
+        },
+        validation: zodAdapter(
+          z
+            .object({
+              password: z.string(),
+              confirm: z.string(),
+            })
+            .refine((data) => data.password === data.confirm, {
+              message: "don't match",
+              path: ['confirm'],
+            }),
+        ),
+      });
+
+      await allSettled(form.fill, {
+        scope,
+        params: { values: { password: '1234', confirm: '00' } },
+      });
+
+      expect(scope.getState(form.$errors)).toStrictEqual({
+        password: null,
+        confirm: "don't match",
+      });
+
+      await allSettled(form.fields.confirm.change, { scope, params: '1234' });
+
+      expect(scope.getState(form.$errors)).toStrictEqual({
+        password: null,
+        confirm: null,
+      });
+    });
+
+    test('works with discriminated union', async () => {
+      const scope = fork();
+
+      const commonSchema = z.object({ name: z.string().nonempty() });
+
+      const form = createForm({
+        schema: {
+          name: '',
+          contractType: '',
+          contractId: '',
+        },
+        validation: zodAdapter(
+          z.discriminatedUnion('contractType', [
+            commonSchema.extend({
+              contractType: z.literal('a'),
+              contractId: z.literal('', {
+                error: () => ({ message: 'should be empty' }),
+              }),
+            }),
+            commonSchema.extend({
+              contractType: z.literal('b'),
+              contractId: z.string().nonempty(),
+            }),
+          ]),
+        ),
+      });
+
+      await allSettled(form.fill, {
+        scope,
+        params: {
+          values: { name: 'Test', contractType: 'a', contractId: '123' },
+        },
+      });
+
+      expect(scope.getState(form.$errors)).toStrictEqual({
+        name: null,
+        contractType: null,
+        contractId: 'should be empty',
+      });
+
+      await allSettled(form.fields.contractType.change, {
+        scope,
+        params: 'b',
+      });
+
+      expect(scope.getState(form.$errors)).toStrictEqual({
+        name: null,
+        contractType: null,
+        contractId: null,
+      });
+    });
+
+    test('errors has right order', async () => {
+      const scope = fork();
+      const form = createForm({
+        schema: {
+          email: '',
+        },
+        validation: zodAdapter(
+          z.object({
+            email: z.string().min(2, 'invalid length').email('invalid email'),
+          }),
+        ),
+      });
+
+      await allSettled(form.fill, {
+        scope,
+        params: { values: { email: '1' } },
+      });
+
+      expect(scope.getState(form.$errors).email).toBe('invalid length');
+    });
+  });
+
+  describe.each([{ z: zodV4mini, mark: "zod v4-mini" }])('$mark', ({ z }) => {
+    test('zod', async () => {
+      const scope = fork();
+      const form = createForm({
+        schema: {
+          a: 5,
+          b: createArrayField<number>([]),
+          c: { d: 'string' },
+        },
+        validation: zodAdapter(
+          z.object({
+            a: z.number().check(z.maximum(20)),
+            b: z.array(z.number()).check(z.minLength(5)).check(z.maxLength(10)),
+            c: z.object({ d: z.string().check(z.minLength(2)).check(z.maxLength(10)) }),
+          }),
+        ),
+      });
+
+      await allSettled(form.validate, { scope });
+      await allSettled(form.fields.c.d.change, { scope, params: 'h' });
+      await allSettled(form.submit, { scope });
+
+      const errors = scope.getState(form.$errors);
+      expect(errors).toStrictEqual({
+        a: null,
+        b: {
+          error: 'Too small: expected array to have >=5 items',
+          errors: [],
+        },
+        c: { d: 'Too small: expected string to have >=2 characters' },
+      });
+    });
+
+    test('clear not settled errors', async () => {
+      const scope = fork();
+      const form = createForm({
+        schema: {
+          a: '',
+          b: '',
+        },
+        validation: zodAdapter(
+          z.object({
+            a: z.string().check(z.minLength(2, 'min 2')),
+            b: z.string().check(z.minLength(4, 'min 4')),
+          }),
+        ),
+      });
+
+      await allSettled(form.fill, {
+        scope,
+        params: { values: { a: 'a', b: 'a' } },
+      });
+
+      expect(scope.getState(form.$errors)).toStrictEqual({
+        a: 'min 2',
+        b: 'min 4',
+      });
+
+      await allSettled(form.fields.a.change, { scope, params: 'aa' });
+
+      expect(scope.getState(form.$errors)).toStrictEqual({
+        a: null,
+        b: 'min 4',
+      });
+    });
+
+    test('works with refine', async () => {
+      const scope = fork();
+      const form = createForm({
+        schema: {
+          password: '',
+          confirm: '',
+        },
+        validation: zodAdapter(
+          z
+            .object({
+              password: z.string(),
+              confirm: z.string(),
+            })
+            .check(
+              z.refine((data) => data.password === data.confirm, {
+                message: "don't match",
+                path: ['confirm'],
+              })
+            ),
+        ),
+      });
+
+      await allSettled(form.fill, {
+        scope,
+        params: { values: { password: '1234', confirm: '00' } },
+      });
+
+      expect(scope.getState(form.$errors)).toStrictEqual({
+        password: null,
+        confirm: "don't match",
+      });
+
+      await allSettled(form.fields.confirm.change, { scope, params: '1234' });
+
+      expect(scope.getState(form.$errors)).toStrictEqual({
+        password: null,
+        confirm: null,
+      });
+    });
+
+    test('works with discriminated union', async () => {
+      const scope = fork();
+
+      const commonSchema = z.object({ name: z.string().check(z.minLength(1)) });
+
+      const form = createForm({
+        schema: {
+          name: '',
+          contractType: '',
+          contractId: '',
+        },
+        validation: zodAdapter(
+          z.discriminatedUnion('contractType', [
+            z.extend(commonSchema, {
+              contractType: z.literal('a'),
+              contractId: z.literal('', {
+                error: () => ({ message: 'should be empty' }),
+              }),
+            }),
+            z.extend(commonSchema, {
+              contractType: z.literal('b'),
+              contractId: z.string().check(z.minLength(1)),
+            }),
+          ]),
+        ),
+      });
+
+      await allSettled(form.fill, {
+        scope,
+        params: {
+          values: { name: 'Test', contractType: 'a', contractId: '123' },
+        },
+      });
+
+      expect(scope.getState(form.$errors)).toStrictEqual({
+        name: null,
+        contractType: null,
+        contractId: 'should be empty',
+      });
+
+      await allSettled(form.fields.contractType.change, {
+        scope,
+        params: 'b',
+      });
+
+      expect(scope.getState(form.$errors)).toStrictEqual({
+        name: null,
+        contractType: null,
+        contractId: null,
+      });
+    });
+
+    test('errors has right order', async () => {
+      const scope = fork();
+      const form = createForm({
+        schema: {
+          email: '',
+        },
+        validation: zodAdapter(
+          z.object({
+            email: z.string().check(z.minLength(2, 'invalid length')).check(z.email('invalid email')),
+          }),
+        ),
+      });
+
+      await allSettled(form.fill, {
+        scope,
+        params: { values: { email: '1' } },
+      });
+
+      expect(scope.getState(form.$errors).email).toBe('invalid length');
+    });
   });
 });

--- a/packages/effector-reform-zod/tests/utils.test.ts
+++ b/packages/effector-reform-zod/tests/utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from 'vitest';
+import { z as zodV3 } from 'zod/v3';
+import { z as zodV4 } from 'zod/v4';
+import { z as zodV4mini } from 'zod/v4-mini';
+import { isZodV4Schema } from '../lib/utils';
+
+describe("utils test", () => {
+  test('should correct detect zod v3 schema', async () => {
+    const schema = zodV3.object({});
+    expect(isZodV4Schema(schema)).toBe(false);
+  });
+
+  test('should correct detect zod v4 schema', async () => {
+    const schema = zodV4.object({});
+    expect(isZodV4Schema(schema)).toBe(true);
+  });
+
+  test('should correct detect zod v4-mini schema', async () => {
+    const schema = zodV4mini.object({});
+    expect(isZodV4Schema(schema)).toBe(true);
+  });
+})


### PR DESCRIPTION
[@effector-reform/zod]
- feat: updated zod package version
- feat: added peerDependencies zod version
- feat: updated tests (expanded for used zod versions: copied, minor changed for zod v4 (errors texts), zod v4-mini (rewrited schemas, errors texts))

P.S.
Saved backward compatibility for the best zod migrations from v3 up to v4: can be used latest zod@^3.25 versions and zod@^4 versions until zod library change it